### PR TITLE
When initializing nand block table use sizeof to set right size for memset

### DIFF
--- a/firmware/nand_bad_block.c
+++ b/firmware/nand_bad_block.c
@@ -13,7 +13,7 @@ static uint32_t nand_bad_block_table[NAND_BAD_BLOCK_TABLE_SIZE];
 
 void nand_bad_block_table_init()
 {
-    memset(nand_bad_block_table, 0, NAND_BAD_BLOCK_TABLE_SIZE);
+    memset(nand_bad_block_table, 0, sizeof(nand_bad_block_table));
     nand_bad_block_table_count = 0;
 }
 


### PR DESCRIPTION
When initializing nand block table use sizeof to set right size for memset.

Since memset works byte by byte and the following table is uint32_t type, essentially memset here sets only 20/4=5 first bytes of table and I don't think that it's intended.

Also, gcc9 is complaining about this aswell:

> nand_bad_block.c: In function 'nand_bad_block_table_init':
nand_bad_block.c:16:5: error: 'memset' used with length equal to number of elements without multiplication by element size [-Werror=memset-elt-size]
   16 |     memset(nand_bad_block_table, 0, NAND_BAD_BLOCK_TABLE_SIZE);
      |     ^~~~~~

with the exact gcc version:
```
# arm-none-eabi-gcc --version
arm-none-eabi-gcc (Arch Repository) 9.2.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```