### PR TITLE
When reading BB marker, store it at the correct buffer offset

### DIFF
--- a/firmware/programmer/nand_programmer.c
+++ b/firmware/programmer/nand_programmer.c
@@ -350,8 +350,8 @@ static int np_read_bad_block_info_from_page(np_prog_t *prog, uint32_t block,
 {
     uint32_t status, addr = block * prog->chip_info.block_size;
 
-    status = nand_read_spare_data(prog->page.buf, page,
-        prog->chip_info.bb_mark_off, 1);
+    status = nand_read_spare_data(&prog->page.buf[prog->chip_info.page_size +
+            prog->chip_info.bb_mark_off], page, prog->chip_info.bb_mark_off, 1);
     if (status == NAND_INVALID_CMD)
     {
         status = nand_read_page(prog->page.buf, page,


### PR DESCRIPTION
Hello again,

Since I started using NANDO, i've always had some issues with reading the bad block markers, which at the time, I thought were due to my inexperience configuring NAND settings.

I've decided to dig on this issue, and it appeared that when specifying a READ SPARE command, the BB marker byte was not stored at the correct position in the buffer, so that when we attempt to check its value, the test would always fail ( Error 113 ).

It would however perform correctly when NOT specifying a READ SPARE command, since it that case it falls back to the standard READ command.

This commit fixes this issue by storing the BB marker at the proper offset.

Regards