### PR TITLE
update firmware and nando programer 3.4.1

### DIFF
--- a/firmware/programmer/chip.h
+++ b/firmware/programmer/chip.h
@@ -15,4 +15,9 @@ typedef struct
     uint8_t fifth_id;
 } chip_id_t;
 
+typedef struct
+{
+    uint8_t id[32];
+}chip_unique_id_t;
+
 #endif /* _CHIP_H_ */

--- a/firmware/programmer/flash_hal.h
+++ b/firmware/programmer/flash_hal.h
@@ -23,9 +23,12 @@ typedef struct
 {
     int (*init)(void *conf, uint32_t conf_size);
     void (*uninit)();
+    void (*reset)();
     void (*read_id)(chip_id_t *chip_id);
+    void (*read_unique_id)(chip_unique_id_t *chip_uid);
+    void (*set_ecc)(int i);
     uint32_t (*erase_block)(uint32_t page);
-    uint32_t (*read_page)(uint8_t *buf, uint32_t page, uint32_t page_size);
+    uint32_t (*read_page)(uint8_t *buf, uint32_t page, uint32_t page_size,int ECC_status);
     uint32_t (*read_spare_data)(uint8_t *buf, uint32_t page, uint32_t offset,
         uint32_t data_size);
     void (*write_page_async)(uint8_t *buf, uint32_t page, uint32_t page_size);

--- a/firmware/programmer/spi_flash.c
+++ b/firmware/programmer/spi_flash.c
@@ -302,7 +302,7 @@ static uint32_t spi_flash_read_data(uint8_t *buf, uint32_t page,
 }
 
 static uint32_t spi_flash_read_page(uint8_t *buf, uint32_t page,
-    uint32_t page_size)
+    uint32_t page_size,int ecc_enabled)
 {
     return spi_flash_read_data(buf, page, 0, page_size);
 }

--- a/firmware/programmer/version.h
+++ b/firmware/programmer/version.h
@@ -8,6 +8,6 @@
 
 #define SW_VERSION_MAJOR 3
 #define SW_VERSION_MINOR 4
-#define SW_VERSION_BUILD 0
+#define SW_VERSION_BUILD 1
 
 #endif

--- a/qt/cmd.h
+++ b/qt/cmd.h
@@ -22,7 +22,11 @@ enum
     CMD_ACTIVE_IMAGE_GET = 0x09,
     CMD_FW_UPDATE_S      = 0x0a,
     CMD_FW_UPDATE_D      = 0x0b,
-    CMD_FW_UPDATE_E      = 0x0c
+    CMD_FW_UPDATE_E      = 0x0c,
+    CMD_NAND_RESET       = 0x0d,
+    CMD_NAND_READ_UNIQUE = 0x0e,
+    CMD_NAND_ECC_E       = 0x0f,
+    CMD_NAND_ECC_D       = 0x10
 };
 
 typedef struct __attribute__((__packed__))
@@ -34,6 +38,7 @@ typedef struct __attribute__((__packed__))
 {
     uint8_t skipBB : 1;
     uint8_t incSpare : 1;
+    uint8_t eccEnabled : 1;
 } CmdFlags;
 
 typedef struct __attribute__((__packed__))
@@ -117,9 +122,14 @@ typedef struct __attribute__((__packed__))
 
 typedef struct __attribute__((__packed__))
 {
+    uint8_t Id[32];
+} ChipUniqueId;
+
+typedef struct __attribute__((__packed__))
+{
     uint8_t code;
     uint8_t info;
-    uint8_t data[];
+    //uint8_t data[];
 } RespHeader;
 
 typedef struct __attribute__((__packed__))

--- a/qt/main_window.h
+++ b/qt/main_window.h
@@ -31,6 +31,7 @@ private:
     QVector<uint8_t> buffer;
     BufferTableModel bufferTableModel;
     ChipId chipId;
+    ChipUniqueId chipuId;
     ParallelChipDb parallelChipDb;
     SpiChipDb spiChipDb;
     ChipDb *currentChipDb;
@@ -49,6 +50,8 @@ private:
 private slots:
     void slotProgConnectCompleted(int status);
     void slotProgReadDeviceIdCompleted(int status);
+    void slotProgResetDeviceCompleted(int status);
+    void slotProgReadUniqueIdCompleted(int status);
     void slotProgReadCompleted(int status);
     void slotProgReadProgress(unsigned int progress);
     void slotProgWriteCompleted(int status);
@@ -57,6 +60,8 @@ private slots:
     void slotProgEraseProgress(unsigned int progress);
     void slotProgReadBadBlocksCompleted(int status);
     void slotProgSelectCompleted(int status);
+    void slotProgEnableEccCompleted(int status);
+    void slotProgDisableEccCompleted(int status);
     void slotProgDetectChipConfCompleted(int status);
     void slotProgDetectChipReadChipIdCompleted(int status);
     void slotProgFirmwareUpdateCompleted(int status);
@@ -65,11 +70,15 @@ public slots:
     void slotFileOpen();
     void slotFileSave();
     void slotProgConnect();
+    void slotProgResetDevice();
+    void slotProgReadUniqueId();
     void slotProgReadDeviceId();
     void slotProgErase();
     void slotProgRead();
     void slotProgWrite();
     void slotProgReadBadBlocks();
+    void slotProgEnableEcc();
+    void slotProgDisableEcc();
     void slotSelectChip(int selectedChipNum);
     void slotDetectChip();
     void slotSettingsProgrammer();

--- a/qt/programmer.h
+++ b/qt/programmer.h
@@ -51,6 +51,7 @@ class Programmer : public QObject
     bool isConn;
     bool skipBB;
     bool incSpare;
+    bool eccEnabled;
     FwVersion fwVersion;
     uint8_t activeImage;
     uint8_t updateImage;
@@ -76,12 +77,16 @@ public:
     void setSkipBB(bool skip);
     bool isIncSpare();
     void setIncSpare(bool incSpare);
+    void resetChip();
     void readChipId(ChipId *chipId);
+    void readChipUniqueId(ChipUniqueId *chipuid);
     void eraseChip(uint32_t addr, uint32_t len);
     void readChip(uint8_t *buf, uint32_t addr, uint32_t len, bool isReadLess);
     void writeChip(uint8_t *buf, uint32_t addr, uint32_t len,
         uint32_t pageSize);
     void readChipBadBlocks();
+    void enableChipEcc();
+    void disableChipEcc();
     void confChip(ChipInfo *chipInfo);
     void detectChip();
     QString fwVersionToString(FwVersion fwVersion);
@@ -89,7 +94,9 @@ public:
 
 signals:
     void connectCompleted(int ret);
+    void resetChipCompleted(int ret);
     void readChipIdCompleted(int ret);
+    void readChipUniqueIdCompleted(int ret);
     void writeChipCompleted(int ret);
     void writeChipProgress(unsigned int progress);
     void readChipCompleted(int ret);
@@ -97,12 +104,16 @@ signals:
     void eraseChipCompleted(int ret);
     void eraseChipProgress(unsigned int progress);
     void readChipBadBlocksCompleted(int ret);
+    void enableChipEccCompleted(int ret);
+    void disableChipEccCompleted(int ret);
     void confChipCompleted(int ret);
     void firmwareUpdateCompleted(int ret);
     void firmwareUpdateProgress(unsigned int progress);
 
 private slots:
+    void resetChipCb(int ret);
     void readChipIdCb(int ret);
+    void readChipUniqueIdCb(int ret);
     void writeCb(int ret);
     void writeProgressCb(unsigned int progress);
     void readCb(int ret);
@@ -110,6 +121,8 @@ private slots:
     void eraseChipCb(int ret);
     void eraseProgressChipCb(unsigned int progress);
     void readChipBadBlocksCb(int ret);
+    void enableChipEccCb(int ret);
+    void disableChipEccCb(int ret);
     void confChipCb(int ret);
     void logCb(QtMsgType msgType, QString msg);
     void connectCb(int ret);

--- a/qt/reader.cpp
+++ b/qt/reader.cpp
@@ -142,6 +142,7 @@ int Reader::handleStatus(char *pbuf, uint32_t len)
 int Reader::handleData(char *pbuf, uint32_t len)
 {
     RespHeader *header = reinterpret_cast<RespHeader *>(pbuf);
+    char *data = pbuf + sizeof(RespHeader);
     uint8_t dataSize = header->info;
     size_t headerSize = sizeof(RespHeader), packetSize = headerSize + dataSize;
 
@@ -161,7 +162,7 @@ int Reader::handleData(char *pbuf, uint32_t len)
         return -1;
     }
 
-    memcpy(rbuf + readOffset, header->data, dataSize);
+    memcpy(rbuf + readOffset, data, dataSize);
     readOffset += dataSize;
     bytesRead += dataSize;
 

--- a/qt/version.h
+++ b/qt/version.h
@@ -6,6 +6,6 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define SW_VERSION "3.4.0"
+#define SW_VERSION "3.4.1"
 
 #endif // VERSION_H

--- a/qt/writer.cpp
+++ b/qt/writer.cpp
@@ -317,7 +317,7 @@ void Writer::serialPortDestroy()
     if (!serialPort)
         return;
     serialPort->stop();
-    free(serialPort);
+    delete serialPort;
     serialPort = nullptr;
 }
 


### PR DESCRIPTION
I added the following :
Reset chip command
Read Unique Id command
Enable ECC
Disable ECC

and fixed the following:
Qt project is now compilable with the latest GCC 10.
a few minor fixes

if ECC is enabled for the chips that support it, the read command will return Bad blocks if the ECC parity bits are wrong.