### PR TITLE
Qt: fix compile error when ODR check enabled.

### DIFF
--- a/qt/parallel_chip_info.cpp
+++ b/qt/parallel_chip_info.cpp
@@ -33,7 +33,7 @@ typedef struct __attribute__((__packed__))
     uint8_t enableEccAddr;
     uint8_t enableEccValue;
     uint8_t disableEccValue;
-} Conf;
+} ParallelChipConf;
 
 ParallelChipInfo::ParallelChipInfo()
 {
@@ -120,7 +120,7 @@ void ParallelChipInfo::chipInfoToStmParams(StmParams *stmParams)
 
 const QByteArray &ParallelChipInfo::getHalConf()
 {
-    Conf conf;
+    ParallelChipConf conf;
     StmParams stmParams;
 
     chipInfoToStmParams(&stmParams);

--- a/qt/spi_chip_info.cpp
+++ b/qt/spi_chip_info.cpp
@@ -17,7 +17,7 @@ typedef struct __attribute__((__packed__))
     uint8_t busy_bit;
     uint8_t busy_state;
     uint32_t freq;
-} Conf;
+} SpiChipConf;
 
 SpiChipInfo::SpiChipInfo()
 {
@@ -30,7 +30,7 @@ SpiChipInfo::~SpiChipInfo()
 
 const QByteArray &SpiChipInfo::getHalConf()
 {
-    Conf conf;
+    SpiChipConf conf;
 
     conf.page_offset = static_cast<uint8_t>(params[CHIP_PARAM_PAGE_OFF]);
     conf.read_cmd = static_cast<uint8_t>(params[CHIP_PARAM_READ_CMD]);


### PR DESCRIPTION
when two structs with the same name, the linker many be confused. when LTO is enabled, ODR checked is required.

```
parallel_chip_info.cpp:36:3: error: type ‘struct Conf’ violates the C++ One Definition Rule [-Werror=odr]
   36 | } Conf;
      |   ^
spi_chip_info.cpp:20:3: note: a different type is defined in another translation unit
   20 | } Conf;
```