### PR TITLE
qt: fix write data is slow

### DIFF
--- a/qt/writer.cpp
+++ b/qt/writer.cpp
@@ -301,7 +301,7 @@ int Writer::writeData()
             break;
     }
 
-    if (read(pbuf, bufSize))
+    if (read(pbuf, writeDataAckLen))
         return -1;
 
     return 0;

--- a/qt/writer.h
+++ b/qt/writer.h
@@ -16,6 +16,7 @@ class Writer : public QObject
     Q_OBJECT
 
     static const uint32_t bufSize = 64;
+    static const uint32_t writeDataAckLen = 10;
 
     SerialPort *serialPort = nullptr;
     QString portName;


### PR DESCRIPTION
    A wait caused slow writing, this patch can provide six times the original writing speed.
    Originally, due to the requested ack data length being 64 bytes, which is much greater than the length of the MCU reply data, Qt would wait for a timeout before executing the callback, resulting in an idle wait of about 30ms.