### PR TITLE
parallel_chip_info.cpp

### DIFF
--- a/qt/parallel_chip_info.cpp
+++ b/qt/parallel_chip_info.cpp
@@ -143,14 +143,10 @@ const QByteArray &ParallelChipInfo::getHalConf()
     conf.erase1Cmd = static_cast<uint8_t>(params[CHIP_PARAM_ERASE1_CMD]);
     conf.erase2Cmd = static_cast<uint8_t>(params[CHIP_PARAM_ERASE2_CMD]);
     conf.statusCmd = static_cast<uint8_t>(params[CHIP_PARAM_STATUS_CMD]);
-    conf.setFeaturesCmd = static_cast<uint8_t>(params[CHIP_PARAM_STATUS_CMD]);
-    conf.enableEccAddr =
-        static_cast<uint8_t>(params[CHIP_PARAM_ENABLE_HW_ECC_ADDR]);
-    conf.enableEccValue =
-        static_cast<uint8_t>(params[CHIP_PARAM_ENABLE_HW_ECC_VALUE]);
-    conf.disableEccValue =
-        static_cast<uint8_t>(params[CHIP_PARAM_DISABLE_HW_ECC_VALUE]);
-
+    conf.setFeaturesCmd = static_cast<uint8_t>(params[CHIP_PARAM_SET_FEATURE_CMD]);
+    conf.enableEccAddr = static_cast<uint8_t>(params[CHIP_PARAM_ENABLE_HW_ECC_ADDR]);
+    conf.enableEccValue = static_cast<uint8_t>(params[CHIP_PARAM_ENABLE_HW_ECC_VALUE]);
+    conf.disableEccValue = static_cast<uint8_t>(params[CHIP_PARAM_DISABLE_HW_ECC_VALUE]);
     halConf.clear();
     halConf.append(reinterpret_cast<const char *>(&conf), sizeof(conf));
 


### PR DESCRIPTION
Fix the duplication in parallel_chip_info.cpp where conf.statusCmd = static_cast<uint8_t>(params[CHIP_PARAM_STATUS_CMD]); and conf.setFeaturesCmd = static_cast<uint8_t>(params[CHIP_PARAM_STATUS_CMD]); are both set. Definition of CHIP_PARAM_STATUS_CMD